### PR TITLE
Add web app for generating Excel from PDF receipts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+*.pyc
+instance/
+uploads/
+*.xlsx

--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
-# receipts
+# Receipts Web App
+
+This simple Flask application lets you upload PDF receipts and generates an Excel file listing each receipt's transaction label, category, and amount. A total of all amounts is added at the bottom of the spreadsheet.
+
+## Setup
+
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Run the app:
+   ```bash
+   python app.py
+   ```
+3. Open your browser at `http://localhost:5000` and upload your PDF receipts.
+
+The generated Excel file will download automatically after processing.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,38 @@
+from flask import Flask, request, render_template, send_file
+from io import BytesIO
+import pandas as pd
+from receipts_parser import parse_receipt
+
+app = Flask(__name__)
+
+@app.route('/', methods=['GET', 'POST'])
+def upload():
+    if request.method == 'POST':
+        files = request.files.getlist('files')
+        records = []
+        for f in files:
+            if not f.filename.lower().endswith('.pdf'):
+                continue
+            f.stream.seek(0)
+            label, category, amount = parse_receipt(f)
+            records.append({'Label': label, 'Category': category, 'Amount': amount})
+        if not records:
+            return 'No valid PDF receipts uploaded.', 400
+        df = pd.DataFrame(records)
+        total = df['Amount'].sum()
+        total_row = pd.DataFrame({'Label': ['Total'], 'Category': [''], 'Amount': [total]})
+        df = pd.concat([df, total_row], ignore_index=True)
+        output = BytesIO()
+        with pd.ExcelWriter(output, engine='openpyxl') as writer:
+            df.to_excel(writer, index=False)
+        output.seek(0)
+        return send_file(
+            output,
+            as_attachment=True,
+            download_name='receipts.xlsx',
+            mimetype='application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+        )
+    return render_template('upload.html')
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/receipts_parser.py
+++ b/receipts_parser.py
@@ -1,0 +1,31 @@
+import re
+import pdfplumber
+
+
+def parse_receipt(file_obj):
+    """Extract label, category, and amount from a PDF receipt.
+
+    Expected fields in the receipt text:
+      - Encaisseur: merchant or transaction label
+      - Code de catégorie du marchand: transaction category
+      - Montant: amount value
+    """
+    file_obj.seek(0)
+    with pdfplumber.open(file_obj) as pdf:
+        text = "\n".join(page.extract_text() or "" for page in pdf.pages)
+
+    label_match = re.search(r"Encaisseur\s*:\s*(.*)", text)
+    category_match = re.search(r"Code de catégorie du marchand\s*:\s*(.*)", text)
+    amount_match = re.search(r"Montant\s*:\s*([0-9]+(?:[.,][0-9]+)?)", text)
+
+    label = label_match.group(1).strip() if label_match else "Unknown"
+    category = category_match.group(1).strip() if category_match else "Unknown"
+    amount_text = amount_match.group(1) if amount_match else "0"
+    amount_text = amount_text.replace(",", ".").strip()
+
+    try:
+        amount_value = float(amount_text)
+    except ValueError:
+        amount_value = 0.0
+
+    return label, category, amount_value

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+Flask
+pandas
+pdfplumber
+openpyxl

--- a/templates/upload.html
+++ b/templates/upload.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Upload Receipts</title>
+</head>
+<body>
+  <h1>Upload PDF Receipts</h1>
+  <form method="post" enctype="multipart/form-data">
+    <input type="file" name="files" multiple accept="application/pdf">
+    <input type="submit" value="Upload">
+  </form>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- build Flask app to upload PDF receipts
- parse receipts with `pdfplumber` and regex
- export Excel listing labels, categories, amounts, and a total
- refine parser for French receipt fields

## Testing
- `python -m py_compile app.py receipts_parser.py`


------
https://chatgpt.com/codex/tasks/task_e_68c6782c37d0832db3fa8a91176c4a83